### PR TITLE
Fix the parsing for the leagues that are in play offs.

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest
   xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.gigaStorm.twinRinks"
-  android:versionCode="5"
-  android:versionName="1.4.0">
+  android:versionCode="6"
+  android:versionName="1.4.1">
 
   <uses-sdk
     android:minSdkVersion="8"

--- a/android/project.properties
+++ b/android/project.properties
@@ -12,5 +12,5 @@
 
 # Project target.
 target=android-19
-android.library.reference.1=../../../libraries/ViewPagerIndicator/library
-android.library.reference.2=../../../libraries/ActionBarSherlock/actionbarsherlock
+android.library.reference.1=..\\..\\actionbarsherlock
+android.library.reference.2=../../JakeWharton-Android-ViewPagerIndicator-8cd549f/library

--- a/android/src/com/gigaStorm/twinRinks/Activity_Main.java
+++ b/android/src/com/gigaStorm/twinRinks/Activity_Main.java
@@ -58,7 +58,7 @@ public class Activity_Main extends SherlockFragmentActivity {
       Logger.enableLogging(Log.ERROR);
     }
     // If there is a need to debug the app, uncomment the following line
-    // Logger.enableLogging(Log.VERBOSE);
+    Logger.enableLogging(Log.VERBOSE);
 
     getWindow().setBackgroundDrawableResource(android.R.color.black);
 

--- a/android/src/com/gigaStorm/twinRinks/Data_FetchTask.java
+++ b/android/src/com/gigaStorm/twinRinks/Data_FetchTask.java
@@ -71,7 +71,6 @@ public class Data_FetchTask extends AsyncTask<Void, Integer, Void> {
     try {
       doc = Jsoup.connect(htmlString).get();
       Elements elems = doc.select("span[style]");
-      Logger.i("Data_FetchTask", "Number of elements: " + elems.size());
 
       for(Element src: elems) {
 
@@ -79,7 +78,6 @@ public class Data_FetchTask extends AsyncTask<Void, Integer, Void> {
         if(line.length() > 70) {
 
           String lineTmp = line.trim().replaceAll("\\s+", " ");
-          Logger.i("Data_FetchTask", "Data: " + src.text());
           // clean up the line. Remove multiple spaces
           lineTmp = line.trim().replaceAll("\\s+", " ");
 
@@ -120,18 +118,36 @@ public class Data_FetchTask extends AsyncTask<Void, Integer, Void> {
           lineTmp = lineTmp.substring(lineTmp.indexOf(' ') + 1,
               lineTmp.length());
 
-          mg.setTeamH(lineTmp.substring(0, lineTmp.indexOf(' ')));
+          // During playoff, the team name is followed by "(n)" indicating final standing
+          String team = lineTmp.substring(0, lineTmp.indexOf(' '));
+          int	indx = team.indexOf('(');
+          if (indx > 0) {
+        	  team = team.substring(0, team.indexOf('('));
+          }
+          mg.setTeamH(team.toUpperCase());
+          
           lineTmp = lineTmp.substring(lineTmp.indexOf(' ') + 1,
               lineTmp.length());
           if(mg.getTeamH().contains("FINALS") || mg.getTeamH().contains("SEMI")) {
             mg.setTeamH("PLAYOFFS");
           }
-
-          mg.setTeamA(lineTmp.substring(0, lineTmp.length()));
-          if(mg.getTeamA().contains("FINALS") || mg.getTeamA().contains("SEMI")) {
-            mg.setTeamA("PLAYOFFS");
+          
+       // During playoff, the team name is followed by "(n)" indicating final standing
+          int sp_loc = lineTmp.indexOf(' ');
+          if (sp_loc > 0) {
+        	  // The is a second team, but it has some text after the team name
+        	  team = lineTmp.substring(0, lineTmp.indexOf(' '));
+          } else {
+        	  // This is a second team. Make sure it's not play off time
+        	  team = lineTmp;
           }
-
+    	  if (team.indexOf('(') > 0)
+    		  team = team.substring(0, team.indexOf('('));
+    	  mg.setTeamA(team.toUpperCase());
+    	  if ( mg.getTeamA().contains ("WIN") || mg.getTeamH().contains ("WIN") ||
+    			  mg.getTeamA().contains("FINALS") || mg.getTeamA().contains("SEMI"))
+    		  continue;
+    	  mg.setTeamA(team.toUpperCase());
           mg.generateCalendarObject();
 
           /*


### PR DESCRIPTION
During play off, the team have the final standings attached
to the end of the team name. ex: Kelly(9). The fix is to extract
the name before '('.

Also, before adding the team to the database, make sure it's not in
the table already.

Special names (PLAYOFF) are no longer will be stored in the teams
database.

Signed-off-by: Boris Dubinsky dubi13@gmail.com
